### PR TITLE
Replace innerHTML with safe method

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -30,7 +30,8 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
                 if (isTextbox(clickedElement)) {
                     clickedElement.value = request.text;
                 } else {
-                    clickedElement.innerHTML = request.text;
+                    let loremText = new DOMParser().parseFromString(request.text, 'text/html').body.childNodes;
+                    clickedElement.parentNode.replaceChildren(...loremText);
                 }
             }
             break;


### PR DESCRIPTION
Fix for #28

Used the suggested DOMParser().parseFromString() method to insert HTML into the DOM. 